### PR TITLE
Do not call `zero(T)` from generated function body

### DIFF
--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -41,9 +41,9 @@ uconvert(a::Units, x::Missing) = missing
     conv = convfact(auobj, xuobj)
 
     t0 = x <: AffineQuantity ? x.parameters[3].parameters[end].parameters[end] :
-        zero(x.parameters[1])
+        :(zero($(x.parameters[1])))
     t1 = a <: AffineUnits ? a.parameters[end].parameters[end] :
-        zero(x.parameters[1])
+        :(zero($(x.parameters[1])))
     quote
         dimension(a) != dimension(x) && return throw(DimensionError(a, x))
         return Quantity(((x.val - $t0) * $conv) + $t1, a)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1498,4 +1498,18 @@ end
     @test isa(TUM.fu^2, TUM.FakeDim212345Units)
 end
 
+
+struct Num <: Real
+   x::Float64
+end
+Base.:+(a::Num, b::Num) = Num(a.x - b.x)
+Base.:-(a::Num, b::Num) = Num(a.x - b.x)
+Base.:*(a::Num, b::Num) = Num(a.x * b.x)
+Base.promote_rule(::Type{Num}, ::Type{<:Real}) = Num
+
+@testset "Custom types" begin
+    # Test that @generated functions work with Quantities + custom types (#231)
+    @test uconvert(u"°C", Num(100)u"K") == Num(373.15)u"°C"
+end
+
 end


### PR DESCRIPTION
This avoids world age errors for user defined types `T` [copied from PainterQubits/Unitful.jl#233].